### PR TITLE
Resetup get students by course

### DIFF
--- a/Lms/LMS.UnitTests/StudentEnrollmentDaoTests.cs
+++ b/Lms/LMS.UnitTests/StudentEnrollmentDaoTests.cs
@@ -97,9 +97,7 @@ namespace LMS.UnitTests
             $" INNER JOIN [LearningManagementSystem].[dbo].[Teacher] ON [LearningManagementSystem].[dbo].[Course].[TeacherId] = [LearningManagementSystem].[dbo].[Teacher].[TeacherId]" +
             $" INNER JOIN [LearningManagementSystem].[dbo].[Semester] ON [LearningManagementSystem].[dbo].[Course].[SemesterId] = [LearningManagementSystem].[dbo].[Semester].[SemesterId]" +
             $" WHERE [LearningManagementSystem].[dbo].[Student].[StudentPhone] = 'test' AND [LearningManagementSystem].[dbo].[Course].[CourseStatus] = 'Active'")), Times.Once);
-        }
-
-       
+        }      
 
         [TestMethod]
         public void GetStudentsByCourseId_UsesProperSqlQuery_OneTime()
@@ -112,7 +110,10 @@ namespace LMS.UnitTests
             _ = sut.GetStudentsByCourseId(1);
 
             // Assert
-            mockSqlWrapper.Verify(sqlWrapper => sqlWrapper.QueryFirstOrDefaultAsync<StudentEnrollmentModel>(It.Is<string>(sql => sql == "SELECT * FROM StudentEnrollmentLog WHERE CourseId = 1")));
+            mockSqlWrapper.Verify(sqlWrapper => sqlWrapper.QueryAsync<StudentModel>(It.Is<string>(sql => sql == $"SELECT * " +
+            $"FROM [LearningManagementSystem].[dbo].[StudentEnrollmentLog]" +
+            $" INNER JOIN [LearningManagementSystem].[dbo].[Student] ON [LearningManagementSystem].[dbo].[Student].[StudentId] = [LearningManagementSystem].[dbo].[StudentEnrollmentLog].[StudentId]" +
+            $"WHERE CourseId = 1")), Times.Once);
         }
     }
 }

--- a/Lms/LMS.UnitTests/StudentEnrollmentDaoTests.cs
+++ b/Lms/LMS.UnitTests/StudentEnrollmentDaoTests.cs
@@ -100,14 +100,14 @@ namespace LMS.UnitTests
         }      
 
         [TestMethod]
-        public void GetStudentsByCourseId_UsesProperSqlQuery_OneTime()
+        public void GetStudentsInCourseByCourseId_UsesProperSqlQuery_OneTime()
         {
             // Arrange
             Mock<ISqlWrapper> mockSqlWrapper = new();
             StudentEnrollmentDao sut = new(mockSqlWrapper.Object);
 
             // Act
-            _ = sut.GetStudentsByCourseId(1);
+            _ = sut.GetStudentsInCourseByCourseId(1);
 
             // Assert
             mockSqlWrapper.Verify(sqlWrapper => sqlWrapper.QueryAsync<StudentModel>(It.Is<string>(sql => sql == $"SELECT * " +

--- a/Lms/Lms/APIErrorHandling/ApiResponse.cs
+++ b/Lms/Lms/APIErrorHandling/ApiResponse.cs
@@ -31,4 +31,3 @@ namespace Lms.APIErrorHandling
         }
     }
 }
-

--- a/Lms/Lms/Controllers/CourseController.cs
+++ b/Lms/Lms/Controllers/CourseController.cs
@@ -144,7 +144,6 @@ namespace Lms.Controllers
             }
         }
 
-
         [HttpPost]
         [Route("StudentInCourse")]
         public async Task<IActionResult> StudentInCourse(StudentInCourseModel addStudentInCourse)
@@ -195,7 +194,7 @@ namespace Lms.Controllers
         }
 
         [HttpDelete]
-        [Route("addStudentInCourse/byStudentCourseId/{studentId},{courseId}")]
+        [Route("StudentInCourse/byStudentCourseId/{studentId},{courseId}")]
         public async Task<IActionResult> DeleteStudentInCourseByStudentCourseId([FromRoute] int studentId, int courseId)
         {
             try

--- a/Lms/Lms/Controllers/StudentController.cs
+++ b/Lms/Lms/Controllers/StudentController.cs
@@ -18,7 +18,6 @@ namespace Lms.Controllers
             this.studentDao = studentDao;
         }
 
-
         [HttpPost]
         [Route("student")]
         public async Task<IActionResult> CreateStudent(StudentModel newStudent)
@@ -121,4 +120,3 @@ namespace Lms.Controllers
         }
     }
 }
-

--- a/Lms/Lms/Controllers/StudentEnrollmentController.cs
+++ b/Lms/Lms/Controllers/StudentEnrollmentController.cs
@@ -101,11 +101,11 @@ namespace Lms.Controllers
 
         [HttpGet]
         [Route("studentsInCourse/byCourseId/{courseId}")]
-        public async Task<IActionResult> GetCourseByCourseId([FromRoute] int courseId)
+        public async Task<IActionResult> GetStudentsInCourseByCourseId([FromRoute] int courseId)
         {
             try
             {
-                var addStudentToCourse = await studentEnrollmentDao.GetStudentsByCourseId(courseId);
+                var addStudentToCourse = await studentEnrollmentDao.GetStudentsInCourseByCourseId(courseId);
                 return Ok(addStudentToCourse);
             }
             catch (Exception e)

--- a/Lms/Lms/Controllers/StudentEnrollmentController.cs
+++ b/Lms/Lms/Controllers/StudentEnrollmentController.cs
@@ -20,7 +20,6 @@ namespace Lms.Controllers
     public class StudentEnrollmentController : ControllerBase
     {
         private IStudentEnrollmentDao studentEnrollmentDao;
-       
 
         public StudentEnrollmentController(IStudentEnrollmentDao studentEnrollmentDao)
         {
@@ -81,7 +80,6 @@ namespace Lms.Controllers
             }
         }
 
-
         [HttpGet]
         [Route("studentActiveEnrollment/byStudentPhone/{studentPhone}")]
         public async Task<IActionResult> GetActiveStudentEnrollmentByStudentPhone([FromRoute] string studentPhone)
@@ -100,6 +98,20 @@ namespace Lms.Controllers
                 return StatusCode(500, e.Message);
             }
         }
+
+        [HttpGet]
+        [Route("studentsInCourse/byCourseId/{courseId}")]
+        public async Task<IActionResult> GetCourseByCourseId([FromRoute] int courseId)
+        {
+            try
+            {
+                var addStudentToCourse = await studentEnrollmentDao.GetStudentsByCourseId(courseId);
+                return Ok(addStudentToCourse);
+            }
+            catch (Exception e)
+            {
+                return StatusCode(500, e.Message);
+            }
+        }
     }
 }
-

--- a/Lms/Lms/Controllers/TeacherController.cs
+++ b/Lms/Lms/Controllers/TeacherController.cs
@@ -18,7 +18,6 @@ namespace Lms.Controllers
             this.teacherDao = teacherDao;
         }
 
-
         [HttpPost]
         [Route("teacher")]
         public async Task<IActionResult> CreateTeacher(TeacherModel newTeacher)

--- a/Lms/Lms/Daos/CourseDao.cs
+++ b/Lms/Lms/Daos/CourseDao.cs
@@ -94,7 +94,9 @@ namespace Lms.Daos
                await sqlWrapper.ExecuteAsync(query);
             }
         }
+
         //-------------Add Student in Course Section-----------------------------------------------------------------------------
+
         public async Task StudentInCourse(StudentInCourseModel addStudentInCourse)
         {
             var query = "INSERT StudentEnrollmentLog (CourseId, StudentId, EnrollmentDate, Cancelled, CancellationReason, HasPassed)" +
@@ -114,7 +116,6 @@ namespace Lms.Daos
                 await sqlWrapper.ExecuteAsync(query, parameters);
             }
         }
-
 
         // PATCH a student within the Enrollment Log.
         public async Task PartiallyUpdateStudentInCourseByCourseStudentId(StudentInCourseModel updateRequest)
@@ -146,7 +147,5 @@ namespace Lms.Daos
                 await sqlWrapper.ExecuteAsync(query);
             }
         }
-
-
     }
 }

--- a/Lms/Lms/Daos/IStudentEnrollmentDao.cs
+++ b/Lms/Lms/Daos/IStudentEnrollmentDao.cs
@@ -9,6 +9,6 @@ namespace Lms.Daos
         Task<IEnumerable<StudentEnrollmentModel>> GetStudentEnrollmentHistoryById(int id);
         Task<IEnumerable<StudentEnrollmentModel>> GetStudentEnrollmentHistoryByStudentLastName(string studentLastName);
         Task<IEnumerable<StudentEnrollmentModel>> GetActiveStudentEnrollmentByStudentPhone(string studentPhone);
-        Task<StudentEnrollmentModel> GetStudentsByCourseId(int id);
+        Task<IEnumerable<StudentModel>> GetStudentsByCourseId(int id);
     }
 }

--- a/Lms/Lms/Daos/IStudentEnrollmentDao.cs
+++ b/Lms/Lms/Daos/IStudentEnrollmentDao.cs
@@ -9,6 +9,6 @@ namespace Lms.Daos
         Task<IEnumerable<StudentEnrollmentModel>> GetStudentEnrollmentHistoryById(int id);
         Task<IEnumerable<StudentEnrollmentModel>> GetStudentEnrollmentHistoryByStudentLastName(string studentLastName);
         Task<IEnumerable<StudentEnrollmentModel>> GetActiveStudentEnrollmentByStudentPhone(string studentPhone);
-        Task<IEnumerable<StudentModel>> GetStudentsByCourseId(int id);
+        Task<IEnumerable<StudentModel>> GetStudentsInCourseByCourseId(int id);
     }
 }

--- a/Lms/Lms/Daos/StudentEnrollmentDao.cs
+++ b/Lms/Lms/Daos/StudentEnrollmentDao.cs
@@ -100,7 +100,7 @@ namespace Lms.Daos
             }
         }
 
-        public async Task<IEnumerable<StudentModel>> GetStudentsByCourseId(int courseId) 
+        public async Task<IEnumerable<StudentModel>> GetStudentsInCourseByCourseId(int courseId) 
         {
             var query = $"SELECT * " +
             $"FROM [LearningManagementSystem].[dbo].[StudentEnrollmentLog]" +

--- a/Lms/Lms/Daos/StudentEnrollmentDao.cs
+++ b/Lms/Lms/Daos/StudentEnrollmentDao.cs
@@ -75,17 +75,17 @@ namespace Lms.Daos
         public async Task<IEnumerable<StudentEnrollmentModel>> GetActiveStudentEnrollmentByStudentPhone(string studentPhone)
         {
             var query = $"SELECT" +
-           $" [LearningManagementSystem].[dbo].[Course].[CourseId]" +
-           $", [LearningManagementSystem].[dbo].[Course].[CourseName]" +
-           $", [LearningManagementSystem].[dbo].[Course].[StartDate]" +
-           $", [LearningManagementSystem].[dbo].[Course].[EndDate]" +
-           $", [LearningManagementSystem].[dbo].[StudentEnrollmentLog].[Cancelled]" +
-           $", [LearningManagementSystem].[dbo].[StudentEnrollmentLog].[CancellationReason]" +
-           $", [LearningManagementSystem].[dbo].[StudentEnrollmentLog].[HasPassed]" +
-           $", [LearningManagementSystem].[dbo].[Teacher].[TeacherEmail]" +
-           $", [LearningManagementSystem].[dbo].[Student].[StudentEmail]" +
-           $", [LearningManagementSystem].[dbo].[Student].[TotalPassCourses]" +
-           $" FROM [LearningManagementSystem].[dbo].[Student]" +
+            $" [LearningManagementSystem].[dbo].[Course].[CourseId]" +
+            $", [LearningManagementSystem].[dbo].[Course].[CourseName]" +
+            $", [LearningManagementSystem].[dbo].[Course].[StartDate]" +
+            $", [LearningManagementSystem].[dbo].[Course].[EndDate]" +
+            $", [LearningManagementSystem].[dbo].[StudentEnrollmentLog].[Cancelled]" +
+            $", [LearningManagementSystem].[dbo].[StudentEnrollmentLog].[CancellationReason]" +
+            $", [LearningManagementSystem].[dbo].[StudentEnrollmentLog].[HasPassed]" +
+            $", [LearningManagementSystem].[dbo].[Teacher].[TeacherEmail]" +
+            $", [LearningManagementSystem].[dbo].[Student].[StudentEmail]" +
+            $", [LearningManagementSystem].[dbo].[Student].[TotalPassCourses]" +
+            $" FROM [LearningManagementSystem].[dbo].[Student]" +
             $" INNER JOIN [LearningManagementSystem].[dbo].[StudentEnrollmentLog] ON [LearningManagementSystem].[dbo].[StudentEnrollmentLog].[StudentId] = [LearningManagementSystem].[dbo].[Student].[StudentId]" +
             $" INNER JOIN [LearningManagementSystem].[dbo].[Course] ON [LearningManagementSystem].[dbo].[StudentEnrollmentLog].[CourseId] = [LearningManagementSystem].[dbo].[Course].[CourseId]" +
             $" INNER JOIN [LearningManagementSystem].[dbo].[Teacher] ON [LearningManagementSystem].[dbo].[Course].[TeacherId] = [LearningManagementSystem].[dbo].[Teacher].[TeacherId]" +
@@ -98,24 +98,20 @@ namespace Lms.Daos
 
                 return studentHistory;
             }
-
         }
 
-
-        // GET specific CourseId within the Enrollment Log.
-        public async Task<StudentEnrollmentModel> GetStudentsByCourseId(int courseId) 
+        public async Task<IEnumerable<StudentModel>> GetStudentsByCourseId(int courseId) 
         {
-            var query = $"SELECT * FROM StudentEnrollmentLog WHERE CourseId = {courseId}";
+            var query = $"SELECT * " +
+            $"FROM [LearningManagementSystem].[dbo].[StudentEnrollmentLog]" +
+            $" INNER JOIN [LearningManagementSystem].[dbo].[Student] ON [LearningManagementSystem].[dbo].[Student].[StudentId] = [LearningManagementSystem].[dbo].[StudentEnrollmentLog].[StudentId]" +
+            $"WHERE CourseId = {courseId}";
 
             using (sqlWrapper.CreateConnection())
             {
-                var course = await sqlWrapper.QueryFirstOrDefaultAsync<StudentEnrollmentModel>(query);
+                var course = await sqlWrapper.QueryAsync<StudentModel>(query);
                 return course;
             }
         }
-
     }
-
 }
-
-

--- a/Lms/Lms/appsettings.json
+++ b/Lms/Lms/appsettings.json
@@ -8,7 +8,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    //"SqlConnection": "server=VUHL-4M2KKN3\\SQLExpress; database=LearningManagementSystem; Integrated Security=True; TrustServerCertificate=True"
-    "SqlConnection": "server=VUHL-DG87LR3\\SQLExpress; database=LearningManagementSystem; Integrated Security=True; TrustServerCertificate=True"
+    "SqlConnection": "server=VUHL-4M2KKN3\\SQLExpress; database=LearningManagementSystem; Integrated Security=True; TrustServerCertificate=True"
+    //"SqlConnection": "server=VUHL-DG87LR3\\SQLExpress; database=LearningManagementSystem; Integrated Security=True; TrustServerCertificate=True"
   }
 }


### PR DESCRIPTION
Somewhere along the lines (assuming whenever we had a bunch of conflicts), we lost the GetStudentsInCourseByCourseId GET endpoint under StudentEnrollment. I added it back with a new name (GetCourseByCourseId -> GetStudentsInCourseByCourseId), query type (QueryFirstOrDefaultAsync -> QueryAsync), new query (inner joins Student table), and student model vice the StudentEnrollment Model. All tests are passing and the endpoint is fully functional.